### PR TITLE
Fix typos and remove undefined code in MediaSession examples

### DIFF
--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -128,19 +128,15 @@ const actionHandlers = [
       await audioEl.play();
       // set playback state
       navigator.mediaSession.playbackState = "playing";
-      // update our status element
-      updateStatus(allMeta[index], "Action: play  |  Track is playing…");
     },
   ],
   [
     "pause",
     () => {
-      // pause out audio
+      // pause our audio
       audioEl.pause();
       // set playback state
       navigator.mediaSession.playbackState = "paused";
-      // update our status element
-      updateStatus(allMeta[index], "Action: pause  |  Track has been paused…");
     },
   ],
 ];


### PR DESCRIPTION
Closes #41250

### Description
This PR resolves an issue with the code samples on the MediaSession API page by making two corrections:
- A typo in a code comment has been corrected (from `// pause out audio` to `// pause our audio`).
- Lines that referenced undefined variables (`updateStatus`, `allMeta`, and `index`) have been removed to avoid confusion.

### Motivation
The motivation for this change is to improve the quality and clarity of the documentation. The existing example was confusing for learners due to the undefined variables and a minor typo, as reported in the issue. This fix ensures the code sample is clean, correct, and easier to understand for developers using MDN.

### Additional details
- No other changes have been made. This PR is a focused effort to correct the specific problems identified in the issue.

